### PR TITLE
Initialize Telegram Mini App skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+*.log
+**/node_modules
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# peemly
-app peemly
+# Peemly (Пимли)
+
+Telegram Mini App for couples and friends.
+
+## Project structure
+
+- `backend/` - Node.js Express server serving API endpoints.
+- `frontend/` - Static frontend files for the Mini App.
+
+## Getting started
+
+```
+cd backend
+npm install
+npm start
+```
+
+Then open `frontend/index.html` in a browser or serve it via a static server.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}
+

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Peemly backend works!');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Peemly Mini App</title>
+</head>
+<body>
+    <h1>Welcome to Peemly</h1>
+    <p>This is the Telegram Mini App frontend.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up basic project architecture for Peemly Telegram Mini App
- add backend with Express server
- add frontend with example HTML page
- document project layout and getting started steps
- ignore node_modules

## Testing
- `npm install` in `backend`
- `npm start` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6860ca3bbb008321ab91572496e6b3b3